### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # MCP Kakao Local
 
-The MCP connects to the [Kakao Local API](https://developers.kakao.com/docs/latest/ko/local/common) and Kakao Map.
-카카오 로컬 API 및 카카오맵에 연결하는 MCP 서버.
+The MCP connects to the [Kakao Local API](https://developers.kakao.com/docs/latest/ko/local/common) and Kakao Map. 카카오 로컬 API 및 카카오맵에 연결하는 MCP 서버.
+
+<a href="https://glama.ai/mcp/servers/@yunkee-lee/mcp-kakao-local">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yunkee-lee/mcp-kakao-local/badge" alt="Kakao Local MCP server" />
+</a>
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR adds a badge for the [MCP Kakao Local](https://glama.ai/mcp/servers/@yunkee-lee/mcp-kakao-local) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yunkee-lee/mcp-kakao-local">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yunkee-lee/mcp-kakao-local/badge" alt="Kakao Local MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.